### PR TITLE
Support valid *non-alphanumeric* characters in table name

### DIFF
--- a/src/DynamoDb.SQL/parser.fs
+++ b/src/DynamoDb.SQL/parser.fs
@@ -67,7 +67,7 @@ module Common =
     let paction = ws >>. choice [pselect; pcount] .>> ws
 
     // parser for table names
-    let isTableName = isLetter <||> isDigit
+    let isTableName = isLetter <||> isDigit <||> isAnyOf ['.'; '-'; '_']
     let pfrom =
         ws
         >>. skipStringCI_ws "from"

--- a/tests/DynamoDb.SQL.Tests/parserTests.fs
+++ b/tests/DynamoDb.SQL.Tests/parserTests.fs
@@ -356,6 +356,12 @@ type ``Given a scan`` () =
         scan.Limit      |> should equal <| Some(Limit 5)
 
     [<Test>]
+    member this.``when table name has valid non-alphanumeric characters it should parse`` () =
+        let select = "SELECT * FROM t-A_b.le1"
+        let scan = parseDynamoScan select
+        scan.From       |> should equal <| From "t-A_b.le1"
+
+    [<Test>]
     member this.``when the SELECT, FROM, WHERE and LIMIT keywords are not in capitals they should still be parsed correctly`` () =
         let select = "sELeCT Name, Age, Salary
                         FrOm Employees


### PR DESCRIPTION
From the [documentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html)

> Table names and secondary index names
> For table and secondary index names, allowed characters are a-z, A-Z, 0-9, '_' (underscore), '-' (dash), and '.' (dot). Names can be between 3 and 255 characters long.
