### PR TITLE
Update paket.dependencies

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,7 +1,7 @@
 source https://www.nuget.org/api/v2
 
 nuget FAKE
-nuget FSharp.Core ~> 3.1
+nuget FSharp.Core >= 3.1.2.5 < 5
 nuget NUnit.Runners ~> 2.6
 nuget NuGet.CommandLine
 


### PR DESCRIPTION
The DynamoDB.SQL package presently restricts the FSharp.Core package to `>=3.1, <4`.

FSharp.Core v3 is compatible with the v4 series of the library, so this is overstrict. Here we open the restriction to accept all of the v4 series, but still assume v5 is incompatible.